### PR TITLE
Add the database and SSH secrets engine paths to 'admins' policy.

### DIFF
--- a/workspaces/vault/config/policies/admin-policy.hcl
+++ b/workspaces/vault/config/policies/admin-policy.hcl
@@ -52,12 +52,12 @@ path "transit/*"
   capabilities = ["create", "read", "update", "delete", "list", "sudo"]
 }
 
-# Manage SSH secrets engine mounted at ssh-client-signer
+# Manage SSH secrets engine mounted at path ssh-client-signer/
 path "ssh-client-signer/*" {
   capabilities = ["create", "read", "update", "delete", "list"]
 }
 
-# Manage database secrets engine at postgres
+# Manage database secrets engine at path postgres/
 path "postgres/*" {
   capabilities = ["create", "read", "update", "delete", "list"]
 }

--- a/workspaces/vault/config/policies/admin-policy.hcl
+++ b/workspaces/vault/config/policies/admin-policy.hcl
@@ -52,6 +52,16 @@ path "transit/*"
   capabilities = ["create", "read", "update", "delete", "list", "sudo"]
 }
 
+# Manage SSH secrets engine mounted at ssh-client-signer
+path "ssh-client-signer/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# Manage database secrets engine at postgres
+path "postgres/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
 # Read health checks
 path "sys/health"
 {


### PR DESCRIPTION
Hope this covers all necessary methods on these mounts.